### PR TITLE
Update link to react RNTester

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,9 +93,9 @@ Uses Three.js via EXGL (an implementation of WebGL for Exponent) for a semi-3d t
 Wang Zixiao  
 Cool NBA App written in RN
 
-[UI Explorer](https://github.com/facebook/react-native/tree/master/Examples/UIExplorer)  
+[RNTester](https://github.com/facebook/react-native/tree/master/RNTester)  
 Facebook  
-The UIExplorer is a sample app that showcases React Native views and modules.
+The RNTester showcases React Native views and modules.
 
 [Multiple Apps by Christopher Dro](https://github.com/christopherdro)  
 Christopher Dro


### PR DESCRIPTION
It seems UIExplorer is now called RNTester (original link was 404)
https://github.com/facebook/react-native/commit/4a80dceac7e35b669301c7aa8180dcd0348f4e93#diff-6bc07ced54417b3ea29686f87e525d08