### PR TITLE
Added MageCart and ARcN

### DIFF
--- a/README.md
+++ b/README.md
@@ -474,9 +474,12 @@ Made with [Typescript](https://github.com/Microsoft/TypeScript-React-Native-Star
 
 [Tone Tracker](https://github.com/charliemcg/ToneTrackerRN) - This app allows users to track the life span of their guitar strings.
 
+[MageCart](https://github.com/alexakasanjeev/magento_react_native) - Magento 2 API based Ecommerce app, that helps you view products and place order.
+
 This list is curated by [Gant Laborde](https://twitter.com/gantlaborde), Chief Technology Strategist of [Infinite Red](https://infinite.red/react-native).
 
 
 ### Boilerplate React Native Apps
 
 [Context API Demo](https://github.com/ToJen/react_native_context_demo) - A simple app showing how Context API can be used in React Native by authenticating users. [Expo](https://expo.io/tools) and [React Navigation](https://reactnavigation.org/) were used for this. This is great for hackathons or quick projects!
+[arcn](https://github.com/alexakasanjeev/arcn) React native boiler plate code based on Atomic design, implements react navigation, redux, redux-saga and storybook 


### PR DESCRIPTION
Added [Magecart](https://github.com/alexakasanjeev/magento_react_native), an ecommerce app written for Magento 2 CMS
Added React native boiler plate code based on Atomic Design [arcn](https://github.com/alexakasanjeev/arcn) that comes with react-navigation, redux, redux-saga and theme support.