### PR TITLE
Extract App list in Markdown Table

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,508 +4,146 @@ React Native Apps is a showcase of only open source React Native apps. These app
 
 To get your project added, please submit a [pull request](https://github.com/ReactNativeNews/React-Native-Apps/pulls).
 
-### Open Source React Native Apps
-
-[QRCode Reader and Generator](https://github.com/insiderdev/qrcode)
-Mobile app for scanning and generating different types of QR Codes.
-* [iTunes Store](https://itunes.apple.com/us/app/id1445350234)
-* [Google Play Store](https://play.google.com/store/apps/details?id=io.insider.apps.qr)
-
-[Movie Swiper](https://github.com/azhavrid/movie-swiper) - Unofficial client for movie service [TMDb](https://www.themoviedb.org).
-
-[Sh**t! I Smoke](https://shootismoke.github.io/)
-See Your City's Air Pollution Measured in Daily Cigarettes. Featured on BBC, Huffpost, CityLab.
-* [iTunes Store](https://itunes.apple.com/us/app/s-i-smoke/id1365605567?mt=8)
-* [Google Play Store](https://play.google.com/store/apps/details?id=com.shitismoke.app)
-* [Expo](https://expo.io/@amaurymartiny/shoot-i-smoke)
-* [Source on Github](https://github.com/amaurymartiny/shoot-i-smoke)
-
-[Quirk CBT](https://github.com/flaque/quirk)
-Cognitive Behavioral Therapy in a sleek, simple React Native app.
-* [ios](https://itunes.apple.com/us/app/quirk-cbt/id1447026451?mt=8)
-
-[System Equation Solver](https://github.com/rezaandwenhao/system-equation-solver) -
-This is a two-unknown-variable system equation solver app. Firebase is used to store the solving history according to username. The equation solver supports integer, negative, decimal and fraction number.
-
-[FastBuy](https://github.com/Bruno-Furtado/fastbuy-app) - App to manage the products from a dummy Store (built with React Native and Redux).
-
-[LBRY](https://github.com/lbryio/lbry-android) - [LBRY](https://lbry.io) is a free, open, and community-run digital marketplace.
-  * [Google Play Store](https://play.google.com/store/apps/details?id=io.lbry.browser)
-
-[Nic or Not](https://github.com/gantman/nicornot) - Detect Nic Cage - http://nicornot.com
-* [iTunes Store](https://itunes.apple.com/us/app/nic-or-not/id1437819644?ls=1&mt=8)
-
-[Facebook F8 App](https://github.com/fbsamples/f8app) - Facebook Official F8 Open Source App
-* [iTunes Store](https://itunes.apple.com/us/app/f8/id853467066)
-* [Google Play Store](https://play.google.com/store/apps/details?id=com.facebook.f8)
-
-[Rocket.Chat Experimental](https://rocket.chat) - Open Source Team Communication
-* [iTunes Store](https://itunes.apple.com/us/app/rocket-chat-experimental/id1272915472)
-* [Google Play Store](https://play.google.com/store/apps/details?id=chat.rocket.reactnative)
-* [Source on Github](https://github.com/RocketChat/Rocket.Chat.ReactNative)
-
-[Hooligram](https://github.com/hooligram/hooligram-client) - Open Source Messaging App
-* [Google Play Store](https://play.google.com/store/apps/details?id=com.hooligram)
-* [Source on GitHub](https://github.com/hooligram/hooligram-client)
-
-[Hide The Notch](https://github.com/MoOx/HideTheNotch) - A wallpaper app to hide the iPhone X notch
-* [iTunes Store](https://itunes.apple.com/us/app/hide-the-notch/id1312839983?ls=1&mt=8)
-
-[RSG Chess](https://github.com/RSG-Group/RSG-Chess-mobile) - Open source chess game built from scratch for the [web](http://rsg-chess.now.sh) and adapted for Android using React Native
-* [Google Play Store](https://play.google.com/store/apps/details?id=com.rsg.chess)
-* [Amazon AppStore](https://www.amazon.com/RSG-Group-Chess/dp/B07D1KWTK7)
-
-[Pocat](https://github.com/rotembcohen/pokerBuddyApp) - Organize casual poker games
-* [Expo](https://expo.io/@rotembcohen/pocat)
-* [iTunes Store](https://itunes.apple.com/us/app/pocat/id1277176782?ls=1&mt=8)
-* [Google Play Store](https://play.google.com/store/apps/details?id=com.hecodesthings.pocat)
-
-[Cryptobullography](https://github.com/WebStew/bullet) - Cryptocurrency converter, manager and tracker.
-* [Expo](https://expo.io/@terminalpunk/bullet)
-* [iTunes Store](https://itunes.apple.com/gb/app/crypto-coin-bull/id1257246245?mt=8)
-* [Google Play Store](https://play.google.com/store/apps/details?id=com.webstew.bullet&hl=en)
-
-[Equation Solver](https://github.com/ebouJ/Equation-Solver) -
-A cross-platform equation solver that solves linear, quadratic,  and cubic equation. Also solves two and three variables simultaneous equation. Heavily typed with typescript.
-
-* [iTunes Store](https://itunes.apple.com/us/app/equation-solver/id1420956198?mt=8)
-
-
-[Boostnote Mobile](https://github.com/BoostIO/boostnote-mobile) - Markdown notepad for programmers!
-* [iTunes Store](https://itunes.apple.com/us/app/boostnote/id1273066636?mt=8)
-* [Google Play Store](https://play.google.com/store/apps/details?id=io.boostnote)
-
-[Gas/Oil Mix Ratio Calculator](https://github.com/filippofilip95/gas-oil-mixture-mobile) - Mobile app which calculate Gasoline/Oil mix ratio for 2 stroke engines.
-* [Google Play Store](https://play.google.com/store/apps/details?id=com.filippofilip.oilratiocalc)
-
-
-[ndash](https://github.com/alexindigo/ndash) - your npm dashboard!
-* [iTunes Store](https://appsto.re/us/nY9Sib.i)
-* [Google Play Store](https://play.google.com/store/apps/details?id=com.ndash)
-
-
-[Chain React Conf](https://github.com/infinitered/ChainReactApp) by Infinite Red - Official Conference App for the [Chain React Conference](https://infinite.red/ChainReactConf)
-* [Google Play Store](https://play.google.com/store/apps/details?id=com.chainreactapp&hl=en)
-* [iTunes Store](https://itunes.apple.com/us/app/chain-react-conf/id1239112816?mt=8)
-
-[Hacker Buzz](https://github.com/RCiesielczuk/HackerBuzz-ReactNative) - A Hacker News Reader App
-* [iTunes Store](https://itunes.apple.com/app/hacker-buzz/id1292825792?mt=8)
-* [Google Play Store](https://play.google.com/store/apps/details?id=com.hackerbuzz)
-
-[Joplin](https://github.com/laurent22/joplin) - a note taking and to-do application with synchronization capabilities for Windows, macOS, Linux, Android and iOS.
-* [iTunes Store](https://itunes.apple.com/us/app/joplin/id1315599797?mt=8)
-* [Google Play Store](https://play.google.com/store/apps/details?id=net.cozic.joplin)
-
-[ComicBook](https://github.com/liyuechun/ComicBook)
-liyuechun
-Cool comic books, supporting iOS and Android.
-
-[Cat or Dog](https://github.com/punksta/Cat-or-dog) - Drag-n-drop mobile game.
-* [Google Play Store](https://play.google.com/store/apps/details?id=com.punksta.apps.sortgame)
-
-[Moonwalk](https://github.com/Illu/moonwalk) - Stay up to date with upcoming rocket launches.
-* [iTunes Store](https://itunes.apple.com/us/app/moonwalk-rocket-launches/id1439376174)
-
-[Yelp Graphql Api Integration](https://github.com/mreorhan/Yelp-Graphql-Integration-with-Apollo-Client) - You can use Yelp Graphql Api with Apollo Client.
-
-[Animavita](https://github.com/wendelfreitas/animavita) - A minimal, clean and beautiful mobile app to help people find the closest pet friend to adopt.
-
-[Daily Prices](http://ansolutions.co/prices-today) - [Google Play Store](https://play.google.com/store/apps/details?id=com.na.prices.today&hl=en)
- AN Solutions
- Daily Prices is an app for showing updated daily products prices in Egypt, Gold and sliver prices and Currency exchange for major banks in Egypt.
-
-
-[What the Thing?](https://github.com/vigzmv/what_the_thing) -  Point camera at things to learn how to say them in a different language.
-
-
-[F1 Stats](https://github.com/srdjanprpa/FormulaOne) - [Google Play Store](https://play.google.com/store/apps/details?id=com.formula1info)
-Srdjan Prpa
-F1 Stats for statistics drivers and teams, calendar of race and results.
-
-[Status](https://status.im) ([Github](https://github.com/status-im/status-react/))
-Status Holdings
-A web3 browser, messenger, and gateway to a decentralised world of Ethereum. Android & iOS.
-
-[React Native Sidemenu](https://github.com/darde/react-native-sidemenu)
-Darde
-A complete template for React Native apps with sidemenu.
-
-[Den](https://github.com/asamiller/den)
-Asa Miller
-iPhone app built with React Native for viewing houses for sale in the Northwest
-
-[DuckDuckGo (Unofficial)](https://github.com/kiok46/duckduckgo)
-Kuldeep Singh
-Unofficial DuckDuckGo App in React-Native.
-
-[SwipeHunt for Product Hunt](https://github.com/notifme/swipehunt)
-A fun minimalistic unofficial client for Product Hunt. crna + expo + native-base
-
-[Feline for Product Hunt](https://github.com/arjunkomath/Feline-for-Product-Hunt/)
-A beautiful, Open Source unofficial Android app for Product Hunt. [Try it here](https://expo.io/@community/feline)
-
-[Floaty Plane](https://github.com/exponentjs/fluxpybird)
-Expo
-Flappy bird, but with a paper airplane. [Try it here](https://getexponent.com/@exponent/floatyplane)
-
-[React Native for Curious People](https://github.com/exponentjs/react-native-for-curious-people)
-Expo
-
-[PomodoroExp](https://github.com/exponentjs/pomodoroexp)
-Expo
-A simple Pomodoro timer for Expo. [Try it here](https://getexponent.com/@exponent/pomodoro)
-
-[Growler Prowler](https://github.com/brentvatne/growler-prowler)
-Expo
-Find craft beer in Vancouver! Collect em all. Looks pretty. [Try it here](https://getexponent.com/@community/growler-prowler)
-
-[Breakout](https://github.com/brentvatne/breakout)
-Expo
-Uses Three.js via EXGL (an implementation of WebGL for Expo) for a semi-3d take on the classic Breakout game. Built for Expo's internal Game Jam. [Try it here](https://getexponent.com/@community/breakout)
-
-[React Native NBA App](https://github.com/wwayne/react-native-nba-app)
-Wang Zixiao
-Cool NBA App written in RN
-
-[RNTester](https://github.com/facebook/react-native/tree/master/RNTester)
-Facebook
-The RNTester showcases React Native views and modules.
-
-[Multiple Apps by Christopher Dro](https://github.com/christopherdro)
-Christopher Dro
-
-[Native Component List](https://github.com/exponentjs/native-component-list)
-Brent Vatne
-Demonstrates a variety of components built into React Native and Expo. [Try it here](https://getexponent.com/@community/native-component-list)
-
-[React Native Github Notetaker](https://github.com/tylermcginnis/react-native-gh-notetaker)
-Tyler Mcginnis
-React Native app using the Github API
-
-[House Control](https://github.com/jordanbyron/house_control)
-Jordan Byron
-React Native port of sinatra based alarm_keypad project
-
-[Hacker News React Native](https://github.com/iSimar/HackerNews-React-Native)
-Simar
-Hacker News iOS and Android App - Made with React Native.
-
-[Zhihu Daily React Native](https://github.com/race604/ZhiHuDaily-React-Native)
-race604
-A Zhihu Daily(http://daily.zhihu.com/) App client implemented using React Native (Android and iOS).
-
-[React Native Example using Instagram](https://github.com/bgryszko/react-native-example)
-Bart Gryszko
-ReactNative iOS app that fetches your current location and display Intstagram photos that were made near to you.
-
-[React Native Movies App](https://github.com/brainattica/react-native-movies-app)
-brainattica
-React Native app that lets you search for your movies and series.
-
-[FinanceReactNative](https://github.com/7kfpun/FinanceReactNative)
-7kfpun
-iOS's Stocks App clone written in React Native.
-
-[Beer Calculator App](https://github.com/HugoDF/beercalculatorapp)
-Hugo
-React Native versions of BeerCalculator
-
-[SoundRedux](https://github.com/fraserxu/soundredux-native#app-example)
-Fraser Xu
-SoundCloud client written in React Native and Redux
-
-[React Native Calculator](https://github.com/benoitvallon/react-native-nw-react-calculator)
-Benoit VALLON
-Mobile, desktop and website Calculator Apps with the same code
-
-[RCTRealtimeNews](https://github.com/realtime-framework/RCTRealtimeNews)
-Realtime Framework
-Enterprise mobile app using React Native and the Realtime Platform
-
-[Guess Famous People Game](https://github.com/DimitriMikadze/react-native-game)
-Dimitri Mikadze
-IOS and Android mobile app "Guess famous people" built on React Native
-
-[FlexBox Froggy](https://github.com/browniefed/flexboxfroggy)
-Jason Brown
-A game for learning flexbox
-
-[Ziliun React Native](https://github.com/sonnylazuardi/ziliun-react-native)
-Sonny Lazuardi
-Ziliun article reader android app built with React Native
-
-[React Native Counter](https://github.com/chentsulin/react-native-counter-ios-android)
-Minimal implement of redux counter example on ReactNative iOS and Android
-C. T. Lin
-
-[React Native Hacker News](https://github.com/jsdf/ReactNativeHackerNews)
-James Friend
-React Native Hacker News app
-
-[React Native Reddit Reader](https://github.com/akveo/react-native-reddit-reader)
-akveo
-Reddit reader for iOS, made with React-Native.
-
-[React Native Premier League](https://github.com/ennioma/react-native-premier-league)
-Ennio
-An unofficial Premier League browser developed with react native
-
-[React Native Meteor](https://github.com/hharnisc/react-native-meteor)
-Harrison Harnisch
-An example that brings Meteor and React Native together (via Objective-DDP and the React Native Bridge)
-
-[Meteor Chat](https://github.com/tgoldenberg/meteor-react-native-chat-example)
-Thomas Goldenberg
-Simple example of live chat through a Meteor server on both iOS and Android with React Native
-
-[TaskRabbit's React Native Sample App](https://github.com/taskrabbit/ReactNativeSampleApp)
-TaskRabbit
-Example app in React Native: sort of like twitter/tumblr
-
-[React Native Meteor Websocket Polyfill](https://github.com/hharnisc/react-native-meteor-websocket-polyfill)
-Harrison Harnisch
-An example that brings Meteor and React Native together (via WebSocket polyfill)
-
-[React Native iTunes Connect](https://github.com/oney/iTunesConnect)
-Howard Yang
-Unofficial iTunes Connect App
-
-[React Native Gallery](https://github.com/reindexio/reindex-examples/tree/master/react-native-gallery)
-Reindex
-Instagram clone. A multi-user gallery app, with file uploads.
-
-[Assemblies](https://github.com/buildreactnative/assemblies)
-Build React Native
-A developer-focused Meetup clone built with React Native
-
-[Reactive 2015 - Ken Wheeler](https://github.com/kenwheeler/reactive2015)
-Ken Wheeler
-Reactive2015 Contest Entry for Reactive Conference
-
-[Reactive 2015 - Jason Brown](https://github.com/browniefed/rncontest)
-Jason Brown
-Reactive2015 Contest Entry for Reactive Conference
-
-[Reactive 2015 - Daniele Zannotti](https://github.com/dzannotti/reactive2015)
-Daniele Zannotti
-Reactive2015 Contest Entry for Reactive Conference
-
-[Reactive 2015 - Alexey](https://github.com/Kureev/Reactive2015)
-Alexey
-Reactive2015 Contest Entry for Reactive Conference
-
-[PocketGear](https://github.com/satya164/PocketGear)
-Satya & Alexey
-Pokédex app for Pokémon GO
-
-[Reading](https://github.com/attentiveness/reading)
-Richard-Cao
-iReading App Write In React-Native（Studying and Programing）
-
-[MovieApp](https://github.com/JuneDomingo/movieapp)
-June Domingo
-Discover movies and tv shows
-
-[Sequent](https://github.com/sobstel/sequent)
-Przemek Sobstel
-Short-term memory training game
-
-[HackerWeb](https://github.com/cheeaun/hackerweb-native)
-Lim Chee Aun
-A simply readable Hacker News app
-
-[Urban Dictionary](https://github.com/edwinbosire/Urbandict)
-Edwin Bosire
-An urban dictionary client.
-
-[React Native Netflix](https://github.com/mariodev12/react-native-netflix)
-Mario Diez
-Netflix App clone
-
-[PÜL](https://github.com/datwheat/pul)
-Juwan Wheatley
-A carpooling app designed for students to help each other get more involved in their community.
-
-[Airbnb Clone](https://github.com/imandyie/react-native-airbnb-clone)
-Andy
-Airbnb clone app using React Native & Redux
-
-[Location Saver](https://github.com/vaskort/react-native)
-Vasilis Kortsimelidis
-Save your location and get directions to it later. [Google Play link](https://play.google.com/store/apps/details?id=com.locationsaver)
-
-[Thousanday - Homepage for pets](https://github.com/byn9826/Thousanday-Mobile)
-Paul Bao
-Photo sharing social app for pets (Instagram/Facebook for pets). [Google Play](https://play.google.com/store/apps/details?id=com.thousanday)
-
-[Clean Timetable](https://github.com/Dennitz/Timetable) - [App Store](https://itunes.apple.com/us/app/clean-timetable/id1242105557?mt=8)
-Dennis Hellweg
-Clean and simple timetable app for iOS.
-
-[Roxie](https://github.com/venepe/react-native-roxie)
-Vernon Pearson
-Rejoice hackers and makers! A music library that talks to your bluetooth devices
-
-[Gitter Mobile](https://github.com/JSSolutions/GitterMobile)
-[JSSolutions](https://github.com/JSSolutions/)
-Unofficial Gitter.im (chat for GitHub) client for iOS and Android, [read more](https://jssolutionsdev.com/portfolio/gitter/)
-
-[Perfi](https://github.com/JSSolutions/Perfi)
-[JSSolutions](https://github.com/JSSolutions/)
-Personal finance assistance, [read more](https://jssolutionsdev.com/portfolio/perfi/)
-
-[SplitCloud](https://github.com/egm0121/splitcloud-app) - [App Store](https://itunes.apple.com/us/app/splitcloud/id1244515007?mt=8)
-Giulio Dellorbo
-Double Music player - share your headphones and play two different tracks from SoundCloud® using one device.
-
-[GitPoint](https://github.com/gitpoint/git-point) - [Google Play](https://play.google.com/store/apps/details?id=com.gitpoint), [iTunes](https://itunes.apple.com/us/app/gitpoint/id1251245162?mt=8)
-A beautiful mobile GitHub client for both iOS and Android.
-
-[PxView](https://github.com/alphasp/pxview) - [Google Play](https://play.google.com/store/apps/details?id=com.utopia.pxview)
-HK Kuah
-An unofficial Pixiv app client for Android and iOS
-
-[Ruk-A-Tuk](https://github.com/akilb/rukatuk-mobile) - [Google Play](https://play.google.com/store/apps/details?id=com.rukatuk.app&hl=en_GB), [iTunes](https://itunes.apple.com/us/app/ruk-a-tuk/id1273614449?ls=1&mt=8)
-Akil Burgess
-The official app for Ruk-A-Tuk Promotions - London's most innovative Caribbean themed parties!
-
-[Musicly](https://github.com/saru2020/Musicly) <br/>
-[Saravanan](https://github.com/saru2020) <br/>
-React Native app/version of Noisli's core functionality! [Read more](https://medium.com/@saruiosdev/musicly-noisli-in-react-native-efd14023bd7c)
-
-[thecatnatice](https://github.com/punksta/thecatnative) - [Google Play](https://play.google.com/store/apps/details?id=com.punksta.apps.kitties)
-The http://thecatapi.com/ unofficial client. Random cat photos and gifs feed.
-
-[MEHNEWS](https://github.com/fromtexas/react-native-news-app) <br/>
-[Veskelen](https://github.com/fromtexas) <br/>
-Get breaking news headlines with short description filtered by your interests and country preferences.
-
-[Zulip Mobile](https://github.com/zulip/zulip-mobile) - The official mobile client for Zulip - powerful open source team chat.
-* [Google Play Store](https://play.google.com/store/apps/details?id=com.zulipmobile)
-* [iTunes Store](https://itunes.apple.com/us/app/zulip/id1203036395)
-
-[Mattermost Mobile Applications](https://github.com/mattermost/mattermost-mobile) - The official React Native mobile clients for Mattermost an open source workplace messaging solution.
-* [iOS](http://about.mattermost.com/mattermost-ios-app/)
-* [Android](http://about.mattermost.com/mattermost-android-app/)
-
-[Online Wallpapers](https://github.com/mrf345/online-wallpapers) <br />
-[Mohamed Feddad](https://github.com/mrf345) <br />
-Android wallpapers manager built with react-native and utlizes reddit api.
-
-[RebelGamer Mobile App](https://github.com/Mokkapps/rebelgamer-mobile-app) - Mobile app for the gaming blog www.rebelgamer.de
-* [iOS](https://itunes.apple.com/de/app/rebelgamer-news-f%C3%BCr-gamer/id1187403828?mt=8)
-* [Android](https://play.google.com/store/apps/details?id=de.rebelgamer.RebelGamerRSS)
-
-[Pride in London App](https://github.com/redbadger/pride-london-app) - Official events app for Pride in London
-* [iTunes Store](https://itunes.apple.com/gb/app/pride-in-london/id1250496471)
-* [Google Play Store](https://play.google.com/store/apps/details?id=org.prideinlondon.festival)
-
-[Forex Rates](https://github.com/MicroPyramid/forex-rates-mobile-app) - Foreign exchange rates, Currency converter mobile app using ReactNative
-* [Google Play Store](https://play.google.com/store/apps/details?id=com.forexrates)
-
-[Parents Soundboard](https://github.com/Mokkapps/parents-soundboard) - A soundboard developed for parents to be able to play often needed phrases like "No"
-* [Android](https://play.google.com/store/apps/details?id=de.mokkapps.parentssoundboard)
-* [iOS](https://itunes.apple.com/us/app/parents-soundboard/id1434425575?mt=8)
-
-
-[Audiobook app](https://github.com/minhtc/sachnoiapp) - A completed audiobook app with some cool animations
-
-[eLadder](https://github.com/bastiRe/eladder) - eLadder is an app to create leagues for Fifa, foosball or similar games. Games can be tracked and players are rated by a custom ELO-system.
-* [iTunes Store](https://itunes.apple.com/de/app/eladder/id1109846671?l=en&mt=8)
-* [Google Play Store](https://play.google.com/store/apps/details?id=de.sebastianrehm.eladder&hl=en)
-
-[Dronk](https://github.com/tiaanduplessis/dronk) - A social drinking game
-
-[Arxiv Papers](https://lopespm.github.io/arxiv-papers-mobile) - ArXiv Papers is a mobile application to search, download and save arXiv papers.
-  * [Google Play Store](https://play.google.com/store/apps/details?id=com.rockbyte.arxiv)
-  * [F-Droid Store](https://f-droid.org/packages/com.rockbyte.arxiv)
-  * [Source on github](https://github.com/lopespm/arxiv-papers-mobile)
-
-[Kitty Rescue](https://github.com/marrionluaka/KittyRescue) - Kitty Rescue is an innovative and fun matching game for all ages to enjoy!
-* [Google Play Store](https://play.google.com/store/apps/details?id=com.kittyrescue)
-
-[Hydropuzzle](https://www.hydropuzzle.com/) - Stylish puzzle adventure
-  * [App Store](https://itunes.apple.com/app/id1294812505?mt=8)
-  * [Google Play Store](https://play.google.com/store/apps/details?id=org.sobstel.hydropuzzle)
-  * [Source on github](https://github.com/hydropuzzle/hydropuzzle)
-
-[Lyrics King](https://github.com/SKempin/Lyrics-King-React-Native) - A beautiful, Open Source Android and iOS app for searching song lyrics.
-* [Expo](https://expo.io/@skempin/lyrics-king)
-
-[React Native boileplate](https://github.com/tawachan/react-native-expo-boilerplate) -  A boilerplate to develop a mobile app with React Native and Expo(v32) using TypeScript and Redux (Redux Saga).
-
-[Thirukkural](https://github.com/Avinash-Raj/thirukkural) - Educational app for learning [thirukkural](https://en.wikipedia.org/wiki/Tirukku%E1%B9%9Ba%E1%B8%B7)
-
-[BMI Calculator](https://github.com/oliver-gomes/react-native-bmi) - Feedback on Body mass index (BMI) to measure body fat based on height and weight.
-* [Expo](https://expo.io/@ogomes/bmi-calculator)
-
-[Modern Twin Calculator](https://github.com/oliver-gomes/react-native-calculator) - Modern Calculator with Day/Night Switch help stand out in dark and light area
-* [Expo](https://expo.io/@ogomes/twin-modern-calculator)
-
-[Github Gist Client - Arjun](https://github.com/Arjun-sna/react-native-githubgist-client)
-Mobile client application for Github Gists
-  * [Google Play Store](https://play.google.com/store/apps/details?id=com.githubgist)
-
-
-[Helo Protocol](https://github.com/gagangoku/helo-protocol-rn)
-Android / IOS app for Helo Protocol. Uses codepush to keep itself up to date.
-  * [Google Play Store](https://play.google.com/store/apps/details?id=com.heloprotocol.customer.app.rn.notificationtester)
-  * [Apple App store](https://itunes.apple.com/gb/app/heloprotocol/id1455721517)
-
-
-[WordsReminder](https://github.com/akiver/wordsreminder) - Save arbitrary words in dictionaries.
-Made with [react-native-firebase](https://github.com/invertase/react-native-firebase) / [TypeScript](http://www.typescriptlang.org/) and [Detox](https://github.com/wix/Detox) for E2E tests.
-Includes a passcode / biometry system powered by [react-native-touch-id](https://github.com/naoufal/react-native-touch-id) and [rn-secure-storage](https://github.com/talut/rn-secure-storage).
-
-[Basic Timer](https://github.com/ReactNativeSchool/react-native-timer) - A simple timer app to help you get up and running with core components and APIs that React Native provides.
-
-[Basic Calculator](https://github.com/ReactNativeSchool/react-native-calculator) - A simple calculator based on iOS', built with React Native!
-
-[Quizz App](https://github.com/ReactNativeSchool/react-native-quiz) - An app to store your knowledge and quiz yourself on it.
-
-
-[Meet Native](https://github.com/beauvaisbruno/meetnative) - An app to locate a language partner.
-Made with [Typescript](https://github.com/Microsoft/TypeScript-React-Native-Starter), [redux-saga](https://github.com/redux-saga/redux-saga), [Storybook](https://github.com/storybooks/storybook), [Firestore](https://firebase.google.com/docs/firestore/), [Firebase Cloud Messaging](https://firebase.google.com/docs/cloud-messaging/), [Firebase Authentication](https://firebase.google.com/docs/auth/), [Graphql](https://graphql.org/) with [Apollo](https://www.apollographql.com/), [Facebook SDK](https://github.com/facebook/react-native-fbsdk)
-
-[eSteem Mobile](https://esteem.app) - Decentralized, rewarding social media.
-* [iTunes Store](https://itunes.apple.com/us/app/esteem-v2/id1451896376)
-* [Google Play Store](https://play.google.com/store/apps/details?id=app.esteem.mobile)
-* [Source on Github](https://github.com/esteemapp/esteem-mobile)
-
-[Bon-Appetit!](https://github.com/steniowagner/bon-appetit-app) - A React-Native App that shows options of Restaurants, Gastronomic Events and Dishes in the City of Fortaleza (Brazil).
-
-[Tip Advisor](https://github.com/charliemcg/TipAdvisor) - Tip calculator which adjusts for country and tipping situation.
-
-[Tone Tracker](https://github.com/charliemcg/ToneTrackerRN) - This app allows users to track the life span of their guitar strings.
-
-[MageCart](https://github.com/alexakasanjeev/magento_react_native) - MageCart is an e-commerce app for Magento 2.1 onwards. It consumes Magento 2 REST API to display catalog, products, add products to cart and let you place order.
-
-[MindCast](https://github.com/steniowagner/mindCast) - A Podcast App that streams audio files from the server and has as main purpose "Share knowledge in the form of podcasts, providing a simple way to learn".
-
-[Chat by Stream](https://github.com/GetStream/stream-chat-react-native) - Build real time chat in less time. Rapidly ship in-app messaging with our highly reliable chat infrastructure. Drive in-app conversion, engagement, and retention with the [Stream Chat](https://getstream.io/chat/) API & SDKs.
-
-[Anime Jisho](https://github.com/AurangzaibRamzan/Anime-jisho) - A React native application for exploring the world of anime which includes multifaceted features including: search on board range of anime, details on particular anime i.e. characters, description, top trends etc.
-
-[NSFWJS Mobile](https://github.com/infinitered/nsfwjs-mobile) - Client-side indecent content checking example app
-* [Blog post](https://shift.infinite.red/nsfw-js-for-react-native-a37c9ba45fe9)
-
-[Ulangi](https://github.com/ulangi/ulangi) - A language learning app with over 20 features (offline access, dark mode, mini-games, built-in dictionary, image search, ...)
-
-[Small Steps](https://github.com/imranariffin/small-steps) - An app that helps you achieve your ambitious goals by focusing on the marginal improvements towards the goals
-* [Google Play Store](https://play.google.com/store/apps/details?id=com.arikama.smallsteps)
-* [Source on GitHub](https://github.com/imranariffin/small-steps)
-
-[NMF.earth](https://nmf.earth/)
-Calculate, understand and reduce your carbon footprint 🌱
-* [iOS](https://apps.apple.com/us/app/nmf-earth/id1494561829)
-* [Android](https://play.google.com/store/apps/details?id=nmf.earth)
-* [Source on Github](https://github.com/NotMyFaultEarth/nmf-app)
+> **Note:** Value in column `React Native Version` & `Last Commit` were last updated on 18 Apr, 2020. Some values might be out-dated.
+
+## Open Source React Native Apps
+
+| Title        | Description           | React Native Version  | Last Commit | Links |
+| ------------ |:---------------------:|:---------------------:|:------------:| ----:|
+| [NMF.earth](https://github.com/NotMyFaultEarth/nmf-app) | Calculate, understand and reduce your carbon footprint 🌱 | Expo sdk 37.0.0 | Apr 17, 2020 | [Website](https://nmf.earth/)<br/> [Apple App Store](https://apps.apple.com/us/app/nmf-earth/id1494561829)<br/> [Google Play Store](https://play.google.com/store/apps/details?id=nmf.earth) |
+| [Sh**t! I Smoke](https://github.com/amaurymartiny/shoot-i-smoke) | See Your City's Air Pollution Measured in Daily Cigarettes. Featured on BBC, Huffpost, CityLab 🚬 | Expo sdk 37.0.0 | Apr 13, 2020  | [Website](https://shootismoke.app/)<br/> [iTunes Store](https://itunes.apple.com/us/app/s-i-smoke/id1365605567?mt=8)<br/> [Google Play Store](https://play.google.com/store/apps/details?id=com.shitismoke.app)<br/> [Expo](https://expo.io/@amaurymartiny/shoot-i-smoke) |
+| [MageCart](https://github.com/alexakasanjeev/magento_react_native) | MageCart is an e-commerce app for Magento 2.1 onwards. It consumes Magento 2 REST API to display catalog, products, add products to cart and let you place order 🛒  | 0.62.2 | Apr 12, 2020 | - |
+| [Ulangi](https://github.com/ulangi/ulangi) | A language learning app with over 20 features (offline access, dark mode, mini-games, built-in dictionary, image search, ...) | 0.61.5 | Apr 12, 2020 | [Website](https://ulangi.com/)<br/> [Apple App Store](https://apps.apple.com/us/app/id1435524341)<br/> [Google Play Store](https://play.google.com/store/apps/details?id=com.ulangi) |
+| [Quirk CBT](https://github.com/flaque/quirk) | Cognitive Behavioral Therapy in a sleek, simple React Native app. | Expo sdk 35.0.0 | Apr 6, 2020  | [Website](https://quirk.fyi)<br/> [ios](https://itunes.apple.com/us/app/quirk-cbt/id1447026451?mt=8) |
+| [Rocket.Chat Experimental](https://github.com/RocketChat/Rocket.Chat.ReactNative) | Open Source Team Communication | 0.61.5 | Apr 15, 2020  | [Website](https://rocket.chat)<br/> [iOS App Store](https://apps.apple.com/us/app/rocket-chat/id1148741252)<br/> [Google Play Store](https://play.google.com/store/apps/details?id=chat.rocket.android) |
+| [Joplin](https://github.com/laurent22/joplin) | A note taking and to-do application with synchronization capabilities for Windows, macOS, Linux, Android and iOS. | 0.61.5 | Apr 18, 2020 | [Website](https://joplinapp.org/)<br/> [iTunes Store](https://itunes.apple.com/us/app/joplin/id1315599797?mt=8)<br/> [Google Play Store](https://play.google.com/store/apps/details?id=net.cozic.joplin) |
+| [Zulip Mobile](https://github.com/zulip/zulip-mobile) | The official mobile client for Zulip - powerful open source team chat. | 0.59.10 | Apr 18, 2020 | [iTunes Store](https://itunes.apple.com/us/app/zulip/id1203036395)<br/> [Google Play Store](https://play.google.com/store/apps/details?id=com.zulipmobile) |
+| [Mattermost Mobile Applications](https://github.com/mattermost/mattermost-mobile) | The official React Native mobile clients for Mattermost an open source workplace messaging solution. | 0.62.2 | Apr 17, 2020 | [Website](https://mattermost.com/)<br/> [Apple App Store](http://about.mattermost.com/mattermost-ios-app/)<br/> [Android](http://about.mattermost.com/mattermost-android-app/)  |
+| [eSteem Mobile](https://github.com/esteemapp/esteem-mobile) | Decentralized, rewarding social media. | 0.61.5 | 8 Apr, 2020 | [Website](https://esteem.app)<br/> [Apple App Store](https://itunes.apple.com/us/app/esteem-v2/id1451896376)<br/> [Google Play Store](https://play.google.com/store/apps/details?id=app.esteem.mobile.android) |
+| [Chat by Stream](https://github.com/GetStream/stream-chat-react-native) | Build real time chat in less time. Rapidly ship in-app messaging with our highly reliable chat infrastructure. Drive in-app conversion, engagement, and retention with the [Stream Chat](https://getstream.io/chat/) API & SDKs. | 0.57.0 | Apr 17, 2020 | [Website](https://getstream.io/chat/) |
+| [RSG Chess](https://github.com/RSG-Group/RSG-Chess-mobile) | Open source chess game built from scratch for the [web](http://rsg-chess.now.sh) and adapted for Android using React Native | 0.55.4 | Apr 18, 2020 | [Website](http://rsg-group.now.sh/)<br/> [Google Play Store](https://play.google.com/store/apps/details?id=com.rsg.chess)<br/> [Amazon AppStore](https://www.amazon.com/RSG-Group-Chess/dp/B07D1KWTK7) |
+| [LBRY](https://github.com/lbryio/lbry-android) | It is a free, open, and community-run digital marketplace. | - | Apr 1, 2020  | [Website](https://lbry.io)<br/> [Google Play Store](https://play.google.com/store/apps/details?id=io.lbry.browser) |
+| [Cat or Dog](https://github.com/punksta/Cat-or-dog) | Drag-n-drop mobile game. | 0.59.4 | Mar 15, 2020 | [Google Play Store](https://play.google.com/store/apps/details?id=com.punksta.apps.sortgame) |
+| [Moonwalk](https://github.com/Illu/moonwalk) | Stay up to date with upcoming rocket launches. | 0.61.5 | Apr 9, 2020 | [iTunes Store](https://itunes.apple.com/us/app/moonwalk-rocket-launches/id1439376174) |
+| [Animavita](https://github.com/wendelfreitas/animavita) | A minimal, clean and beautiful mobile app to help people find the closest pet friend to adopt. | Expo sdk 36.0.1 | Mar 7, 2020 | - |
+| [Status](https://github.com/status-im/status-react/) | A web3 browser, messenger, and gateway to a decentralised world of Ethereum. Android & iOS. | - | Apr 17, 2020  | [Website](https://status.im) |
+| [RNTester](https://github.com/facebook/react-native/tree/master/RNTester) | The RNTester showcases React Native views and modules.(Facebook) | - | Apr 17, 2020 |
+| [Native Component List](https://github.com/expo/expo/tree/master/apps/native-component-list) | Demonstrates a variety of components built into React Native and Expo. | 0.61.4 | Apr 10, 2020 | [Expo](https://getexponent.com/@community/native-component-list) |
+| [PocketGear](https://github.com/satya164/PocketGear) | Pokédex app for Pokémon GO | Expo sdk 34.0.0 | Jan 9, 2020 | - |
+| [Clean Timetable](https://github.com/Dennitz/Timetable) | Clean and simple timetable app for iOS. | 0.50.4 | Jan 25, 2020 | [Apple App Store](https://itunes.apple.com/us/app/clean-timetable/id1242105557?mt=8) |
+| [RebelGamer Mobile App](https://github.com/Mokkapps/rebelgamer-mobile-app) | Mobile app for the gaming blog www.rebelgamer.de | 0.61.3 |  Mar 19, 2020 | [Apple App Store](https://itunes.apple.com/de/app/rebelgamer-news-f%C3%BCr-gamer/id1187403828?mt=8)<br /> [Android](https://play.google.com/store/apps/details?id=de.rebelgamer.RebelGamerRSS) |
+| [Parents Soundboard](https://github.com/Mokkapps/parents-soundboard) | A soundboard developed for parents to be able to play often needed phrases like "No" | 0.60.5 | Mar 19, 2020 | [Apple App Store](https://itunes.apple.com/us/app/parents-soundboard/id1434425575?mt=8)<br/> [Google Play Store](https://play.google.com/store/apps/details?id=de.mokkapps.parentssoundboard) |
+| [WordsReminder](https://github.com/akiver/wordsreminder) | Save arbitrary words in dictionaries. Made with [react-native-firebase](https://github.com/invertase/react-native-firebase), [TypeScript](http://www.typescriptlang.org/) and [Detox](https://github.com/wix/Detox) for E2E tests. Includes a passcode / biometry system powered by [react-native-touch-id](https://github.com/naoufal/react-native-touch-id) and [rn-secure-storage](https://github.com/talut/rn-secure-storage). | 0.62.0 | Mar 14, 2020 | - |
+| [Basic Timer](https://github.com/ReactNativeSchool/react-native-timer) | A simple timer app to help you get up and running with core components and APIs that React Native provides. | Expo sdk 37.0.0 | Apr 8, 2020 | - |
+| [Basic Calculator](https://github.com/ReactNativeSchool/react-native-calculator) | A simple calculator based on iOS', built with React Native. | Expo sdk 37.0.0 | Apr 8, 2020 | - |
+| [Quizz App](https://github.com/ReactNativeSchool/react-native-quiz) | An app to store your knowledge and quiz yourself on it. | Expo sdk 37.0.0 | Apr 8, 2020 | - |
+| [Small Steps](https://github.com/imranariffin/small-steps) | An app that helps you achieve your ambitious goals by focusing on the marginal improvements towards the goals | 0.60.5 | Feb 22, 2020 | [Google Play Store](https://play.google.com/store/apps/details?id=com.arikama.smallsteps) |
+| [Nic or Not](https://github.com/gantman/nicornot) | Detect Nic Cage | 0.55.4 | Mar 16, 2020 |[Website](http://nicornot.com)<br/> [iTunes Store](https://itunes.apple.com/us/app/nic-or-not/id1437819644?ls=1&mt=8) |
+| [QRCode Reader and Generator](https://github.com/insiderdev/react-native-qrcode-app)| Mobile app for scanning and generating different types of QR Codes. | 0.36.1 | Dec 10, 2016 | [iTunes Store](https://itunes.apple.com/us/app/id1445350234)<br/> [Google Play Store](https://play.google.com/store/apps/details?id=io.insider.apps.qr) |
+| [Movie Swiper](https://github.com/azhavrid/movie-swiper) | Unofficial client for movie service | 0.57.8 | Jun 27, 2019 | [TMDb](https://www.themoviedb.org/) |
+| [System Equation Solver](https://github.com/rezaandwenhao/system-equation-solver) | This is a two-unknown-variable system equation solver app. Firebase is used to store the solving history according to username. The equation solver supports integer, negative, decimal and fraction number. | 0.55.2 | Jul 2, 2019 | - |
+| [FastBuy](https://github.com/Bruno-Furtado/fastbuy-app) | App to manage the products from a dummy Store (built with React Native and Redux) | 0.57.4 | Nov 12, 2018 | - |
+| [Facebook F8 App](https://github.com/fbsamples/f8app) | Facebook Official F8 Open Source App | 0.44.0 | Apr 19, 2018   | [Website](https://fbf8.com)<br/> [iTunes Store](https://itunes.apple.com/us/app/f8/id853467066) |
+| [Hooligram](https://github.com/hooligram/hooligram-client) | Open Source Messaging App | 0.57.8 | May 5, 2019 | - |
+| [Hide The Notch](https://github.com/MoOx/HideTheNotch) | A wallpaper app to hide the iPhone X notch | 0.49.0 | Nov 24, 2017 | [Website]()<br/> [iTunes Store](https://itunes.apple.com/us/app/hide-the-notch/id1312839983?ls=1&mt=8) |
+| [Pocat](https://github.com/rotembcohen/pokerBuddyApp) | Organize casual poker games | Expo sdk 23.0.0 | Dec 28, 2017 | [iTunes Store](https://itunes.apple.com/us/app/pocat/id1277176782?ls=1&mt=8)<br/> [Expo](https://expo.io/@rotembcohen/pocat) |
+| [Cryptobullography](https://github.com/WebStew/bullet) | Cryptocurrency converter, manager and tracker. | Expo sdk 20.0.0 | Jan 19, 2018 | [iTunes Store](https://itunes.apple.com/gb/app/crypto-coin-bull/id1257246245?mt=8)<br/> [Expo](https://expo.io/@terminalpunk/bullet) |
+| [Equation Solver](https://github.com/ebouJ/Equation-Solver) | A cross-platform equation solver that solves linear, quadratic,  and cubic equation. Also solves two and three variables simultaneous equation. Heavily typed with typescript. | 0.55.4 | Nov 20, 2018 | [iTunes Store](https://itunes.apple.com/us/app/equation-solver/id1420956198?mt=8) |
+| [ndash](https://github.com/alexindigo/ndash) | your npm dashboard. | 0.42.3 | Oct 21, 2017 | [iTunes Store](https://appsto.re/us/nY9Sib.i) |
+| [Chain React Conf](https://github.com/infinitered/ChainReactApp) | by Infinite Red - Official Conference App for the [Chain React Conference](https://infinite.red/ChainReactConf) | 0.45.1 | Feb 13, 2018 | [iTunes Store](https://itunes.apple.com/us/app/chain-react-conf/id1239112816?mt=8)<br/> [Google Play Store](https://play.google.com/store/apps/details?id=com.chainreactapp&hl=en)  |
+| [Hacker Buzz](https://github.com/RCiesielczuk/HackerBuzz-ReactNative) | A Hacker News Reader App | 0.44.1 | Dec 26, 2017 | [iTunes Store](https://itunes.apple.com/app/hacker-buzz/id1292825792?mt=8) |
+| [ComicBook](https://github.com/liyuechun/ComicBook) | liyuechun Cool comic books, supporting iOS and Android. | 0.43.3 | Jun 15, 2017 | - |
+| [Yelp Graphql Api Integration](https://github.com/mreorhan/Yelp-Graphql-Integration-with-Apollo-Client) | You can use Yelp Graphql Api with Apollo Client. | 0.59.8 | Jun 8, 2019 | - |
+| [What the Thing?](https://github.com/vigzmv/what_the_thing) | Point camera at things to learn how to say them in a different language. | 0.41.2 | Oct 28, 2018 | [Website](https://vigneshm.com/what_the_thing/) |
+| [F1 Stats](https://github.com/srdjanprpa/FormulaOne) | F1 Stats for statistics drivers and teams, calendar of race and results. | 0.44.0 | Jun 11, 2017 | - |
+| [React Native Sidemenu](https://github.com/darde/react-native-sidemenu) | A template for react native apps with sidemenu.  | 0.57.8 | Jan 13, 2019 | - |
+| [Den](https://github.com/asamiller/den) | iPhone app built with React Native for viewing houses for sale in the Northwest | 0.17.0 | Jan 15, 2016 | - |
+| [DuckDuckGo (Unofficial)](https://github.com/kiok46/duckduckgo) | Unofficial DuckDuckGo App in React-Native. | 0.50.3 | Feb 18, 2018 | - |
+| [SwipeHunt for Product Hunt](https://github.com/notifme/swipehunt) | A fun minimalistic unofficial client for Product Hunt. crna + expo + native-base | 0.45.1 | Jul 31, 2017 | - |
+| [Feline for Product Hunt](https://github.com/arjunkomath/Feline-for-Product-Hunt/) | A beautiful, Open Source unofficial Android app for Product Hunt.  | 0.44.2 | Nov 20, 2019 | [Expo](https://expo.io/@community/feline) |
+| [Floaty Plane](https://github.com/exponentjs/fluxpybird) | Flappy bird, but with a paper airplane.  | Expo sdk 9.0.0 | Mar 22, 2016 | [Expo](https://getexponent.com/@exponent/floatyplane) |
+| [React Native for Curious People](https://github.com/exponentjs/react-native-for-curious-people) | - | Expo sdk 15.0.0 | Apr 15, 2017 | - |
+| [PomodoroExp](https://github.com/exponentjs/pomodoroexp) | A simple Pomodoro timer for Expo. | Expo sdk 21.0.0 | Mar 3, 2017 | [Expo](https://getexponent.com/@exponent/pomodoro) |
+| [Growler Prowler](https://github.com/brentvatne/growler-prowler) | Find craft beer in Vancouver! Collect em all. Looks pretty. | Expo sdk 30.0.0 | Feb 5, 2019 | [Expo](https://getexponent.com/@community/growler-prowler) |
+| [Breakout](https://github.com/brentvatne/breakout) | Uses Three.js via EXGL (an implementation of WebGL for Expo) for a semi-3d take on the classic Breakout game. Built for Expo's internal Game Jam.   | Expo sdk 11.0.0 | Nov 26, 2016 | [Expo](https://getexponent.com/@community/breakout) |
+| [React Native NBA App](https://github.com/wwayne/react-native-nba-app) | Cool NBA App written in RN | 0.17.0 | Jan 23, 2016 | - |
+| [react-native-sudoku](https://github.com/christopherdro/react-native-sudoku)| A simple Sudoku game built with React Native. | 0.5.0 | Jun 6, 2015 | - |
+| [React Native Github Notetaker](https://github.com/tylermcginnis/react-native-gh-notetaker) | React Native app using the Github API  | 0.3.3 | Apr 7, 2015 | - |
+| [House Control](https://github.com/jordanbyron/house_control) | React Native port of sinatra based alarm_keypad project | 0.57.3 | Nov 21, 2018 | - |
+| [Zhihu Daily React Native](https://github.com/race604/ZhiHuDaily-React-Native) | A Zhihu Daily App client implemented using React Native | 0.17.0 | Dec 25, 2015 | [Website](http://daily.zhihu.com/) |
+| [React Native Example using Instagram](https://github.com/bgryszko/react-native-example) | ReactNative iOS app that fetches your current location and display Intstagram photos that were made near to you. | 0.11.0 | Sep 25, 2015 | - |
+| [React Native Movies App](https://github.com/brainattica/react-native-movies-app) | React Native app that lets you search for your movies and series. | 0.12.0 |  Oct 13, 2015 | - |
+| [SoundRedux](https://github.com/fraserxu/soundredux-native#app-example) | SoundCloud client written in React Native and Redux | 0.14.0 | Dec 4, 2015 | - |
+| [React Native Calculator](https://github.com/benoitvallon/react-native-nw-react-calculator) | Mobile, desktop and website Calculator Apps with the same code | 0.21.0 | Feb 10, 2017 | - |
+| [RCTRealtimeNews](https://github.com/realtime-framework/RCTRealtimeNews) | Enterprise mobile app using React Native and the Realtime Platform | 0.14.2 | Nov 18, 2015 | - |
+| [Guess Famous People Game](https://github.com/DimitriMikadze/react-native-game) | IOS and Android mobile app "Guess famous people" built on React Native | 0.16.0 | Apr 3, 2018 | - |
+| [Ziliun React Native](https://github.com/sonnylazuardi/ziliun-react-native) | Ziliun article reader android app built with React Native | 0.17.0 | Jan 2, 2016 | - |
+| [React Native Counter](https://github.com/chentsulin/react-native-counter-ios-android) | Minimal implement of redux counter example on ReactNative iOS and Android | 0.48.1 | Sep 11, 2017 | - |
+| [React Native Hacker News](https://github.com/jsdf/ReactNativeHackerNews) | React Native Hacker News app | 0.4.1 | May 10, 2015 | - |
+| [React Native Reddit Reader](https://github.com/akveo/react-native-reddit-reader) | Reddit reader for iOS, made with React-Native. | 0.16.0 | Apr 8, 2016 | - |
+| [React Native Premier League](https://github.com/ennioma/react-native-premier-league) | An unofficial Premier League browser developed with react native | 0.2.1 | Apr 1, 2015 | - |
+| [Meteor Chat](https://github.com/tgoldenberg/meteor-react-native-chat-example) | Simple example of live chat through a Meteor server on both iOS and Android with React Native | 0.14.2 | Nov 17, 2015 | - |
+| [TaskRabbit's React Native Sample App](https://github.com/taskrabbit/ReactNativeSampleApp) | Example app in React Native: sort of like twitter/tumblr | 0.38.0 | Dec 1, 2016 | - |
+| [React Native Meteor Websocket Polyfill](https://github.com/hharnisc/react-native-meteor-websocket-polyfill) | An example that brings Meteor and React Native together (via WebSocket polyfill) | 0.6.0 | Sep 10, 2015 | - |
+| [React Native iTunes Connect](https://github.com/oney/iTunesConnect) | Unofficial iTunes Connect App | 0.19.0 | Feb 26, 2016 | - |
+| [React Native Gallery](https://github.com/reindexio/reindex-examples/tree/master/react-native-gallery) | Instagram clone. A multi-user gallery app, with file uploads. | 0.22.0 | May 10, 2016 | - |
+| [Assemblies](https://github.com/buildreactnative/assemblies) | A developer-focused Meetup clone built with React Native | 0.39.0 | Jan 18, 2017 | - |
+| [Reactive 2015 - Ken Wheeler](https://github.com/kenwheeler/reactive2015) | Reactive2015 Contest Entry for Reactive Conference | 0.11.4 | Oct 11, 2015 | - |
+| [Reactive 2015 - Jason Brown](https://github.com/browniefed/rncontest) | Reactive2015 Contest Entry for Reactive Conference | 0.11.4 | Oct 8, 2015 | - |
+| [Reactive 2015 - Daniele Zannotti](https://github.com/dzannotti/reactive2015) | Reactive2015 Contest Entry for Reactive Conference | 0.11.4 | Nov 25, 2015 | - |
+| [Reactive 2015 - Alexey](https://github.com/Kureev/Reactive2015) | Reactive2015 Contest Entry for Reactive Conference | 0.11.4 | Oct 16, 2015 | - |
+| [Reading](https://github.com/attentiveness/reading) | iReading App Write In React-Native（Studying and Programing） | 0.55.4 | Oct 15, 2019 | - |
+| [MovieApp](https://github.com/JuneDomingo/movieapp) | Discover movies and tv shows | 0.44.0 | Jan 9, 2018 | - |
+| [Sequent](https://github.com/sobstel/sequent) | Short-term memory training game | 0.39.2 | Dec 12, 2019 | - |
+| [HackerWeb](https://github.com/cheeaun/hackerweb-native) | A simply readable Hacker News app | 0.27.2 | Jun 12, 2016 | - |
+| [Urban Dictionary](https://github.com/edwinbosire/Urbandict) | An urban dictionary client. | 0.40.0 | Jun 28, 2017 | - |
+| [React Native Netflix](https://github.com/mariodev12/react-native-netflix) | Netflix App clone | 0.50.4 | Mar 16, 2019 | - |
+| [PÜL](https://github.com/datwheat/pul) | A carpooling app designed for students to help each other get more involved in their community. | Expo sdk 17.0.0 | Sep 21, 2017 | - |
+| [Airbnb Clone](https://github.com/imandyie/react-native-airbnb-clone) | Airbnb clone app using React Native & Redux | 0.56.0 | May 28, 2019 | - |
+| [Location Saver](https://github.com/vaskort/react-native) | Save your location and get directions to it later. | 0.39.2 | Oct 26, 2018 | [Google Play](https://play.google.com/store/apps/details?id=com.locationsaver) |
+| [Thousanday - Homepage for pets](https://github.com/byn9826/Thousanday-Mobile) | Photo sharing social app for pets (Instagram/Facebook for pets). | 0.44.0 | Mar 12, 2019 | - |
+| [Roxie](https://github.com/venepe/react-native-roxie) | Rejoice hackers and makers! A music library that talks to your bluetooth devices | 0.41.0 | Jun 8, 2017 | - |
+| [Gitter Mobile](https://github.com/JSSolutions/GitterMobile) | Unofficial Gitter.im (chat for GitHub) client for iOS and Android | 0.44.3 | Feb 12, 2018 | [Website](https://apiko.com/portfolio/gitter-react-native-app/) |
+| [Perfi](https://github.com/apiko-dev/Perfi) | Personal finance assistance | 0.55.2 | Oct 23, 2018 | [Apple App Store](https://itunes.apple.com/us/app/perfi/id1437633955?mt=8&ign-mpt=uo%3D4)<br/> [Google Play Store](https://play.google.com/store/apps/details?id=com.apikodev.perfi&hl=uz) |
+| [SplitCloud](https://github.com/egm0121/splitcloud-app) | Double Music player - share your headphones and play two different tracks from SoundCloud® using one device. | 0.30.0 | Apr 23, 2019 | [Apple App Store](https://itunes.apple.com/us/app/splitcloud/id1244515007?mt=8) |
+| [GitPoint](https://github.com/gitpoint/git-point) | A beautiful mobile GitHub client for both iOS and Android. | 0.59.9 | Nov 11, 2019 | [Website](https://gitpoint.co/)<br/> [iTunes](https://itunes.apple.com/us/app/gitpoint/id1251245162?mt=8)<br /> [Google Play](https://play.google.com/store/apps/details?id=com.gitpoint) |
+| [PxView](https://github.com/alphasp/pxview) | An unofficial Pixiv app client for Android and iOS | 0.61.2 | Oct 24, 2019 | [Google Play](https://play.google.com/store/apps/details?id=com.utopia.pxview) |
+| [Ruk-A-Tuk](https://github.com/akilb/rukatuk-mobile) | The official app for Ruk-A-Tuk Promotions - London's most innovative Caribbean themed parties! | 0.55.4 | Jun 12, 2018 | [iTunes](https://itunes.apple.com/us/app/ruk-a-tuk/id1273614449?ls=1&mt=8)<br/> [Google Play](https://play.google.com/store/apps/details?id=com.rukatuk.app&hl=en_GB)  |
+| [Musicly](https://github.com/saru2020/Musicly) | Mix different sounds and create your perfect sound environment to work and relax. | 0.49.5 | Jun 5, 2019 | [Website](https://medium.com/@saruiosdev/musicly-noisli-in-react-native-efd14023bd7c) |
+| [thecatnatice](https://github.com/punksta/thecatnative) | The (theCatApi)[http://thecatapi.com/] unofficial client. Random cat photos and gifs feed. | 0.58.4 | Feb 20, 2019 | [Google Play](https://play.google.com/store/apps/details?id=com.punksta.apps.kitties) |
+| [MEHNEWS](https://github.com/fromtexas/react-native-news-app) | Get breaking news headlines with short description filtered by your interests and country preferences. | Expo sdk 31.0.0 | Dec 19, 2018 | - |
+| [Online Wallpapers](https://github.com/mrf345/online-wallpapers) | Android wallpapers manager built with react-native and utlizes reddit api. | 0.55.4 | Jun 7, 2018 | - |
+| [Pride in London App](https://github.com/redbadger/pride-london-app) | Official events app for Pride in London | 0.57.8 | Dec 21, 2018 | [Apple App Store](https://itunes.apple.com/gb/app/pride-in-london/id1250496471)<br/> [Google Play Store](https://play.google.com/store/apps/details?id=org.prideinlondon.festival) |
+| [Forex Rates](https://github.com/MicroPyramid/forex-rates-mobile-app) | Foreign exchange rates, Currency converter mobile app using ReactNative | 0.56.0 | Sep 11, 2018 | [Google Play Store](https://play.google.com/store/apps/details?id=com.forexrates) |
+| [Audiobook app](https://github.com/minhtc/sachnoiapp) | A completed audiobook app with some cool animations | 0.59.9 | Oct 8, 2019 |  |
+| [eLadder](https://github.com/bastiRe/eladder) | eLadder is an app to create leagues for Fifa, foosball or similar games. Games can be tracked and players are rated by a custom ELO-system. | Expo sdk 33.0.0 | Jul 24, 2019 | [Apple App Store](https://itunes.apple.com/de/app/eladder/id1109846671?l=en&mt=8)<br/> [Google Play Store](https://play.google.com/store/apps/details?id=de.sebastianrehm.eladder&hl=en) |
+| [Dronk](https://github.com/tiaanduplessis/dronk) | A social drinking game | Expo sdk 30.0.0 | Sep 6, 2019 | - |
+| [Arxiv Papers](https://github.com/lopespm/arxiv-papers-mobile) | ArXiv Papers is a mobile application to search, download and save arXiv papers. | 0.51.0 | Jul 4, 2019 | [Arxiv Papers](https://lopespm.github.io/arxiv-papers-mobile)<br/> [Google Play Store](https://play.google.com/store/apps/details?id=com.rockbyte.arxiv)<br/> [F-Droid Store](https://f-droid.org/packages/com.rockbyte.arxiv) |
+| [Kitty Rescue](https://github.com/marrionluaka/KittyRescue) | Kitty Rescue is an innovative and fun matching game for all ages to enjoy. | 0.50.4 | Oct 21, 2018 | [Google Play Store](https://play.google.com/store/apps/details?id=com.kittyrescue) |
+| [Hydropuzzle](https://github.com/hydropuzzle/hydropuzzle) | Stylish puzzle adventure | 0.57.8 | Dec 12, 2019 | [Website](https://www.hydropuzzle.com/)<br/> [Apple App Store](https://itunes.apple.com/app/id1294812505?mt=8)<br/> [Google Play Store](https://play.google.com/store/apps/details?id=org.sobstel.hydropuzzle) |
+| [Lyrics King](https://github.com/SKempin/Lyrics-King-React-Native) | A beautiful, Open Source Android and iOS app for searching song lyrics. | Expo sdk 32.0.0 | Mar 27, 2019 | [Expo](https://expo.io/@skempin/lyrics-king) |
+| [Thirukkural](https://github.com/Avinash-Raj/thirukkural) | Educational app for learning  | 0.58.4 | Feb 25, 2019 | [thirukkural](https://en.wikipedia.org/wiki/Tirukku%E1%B9%9Ba%E1%B8%B7) |
+| [BMI Calculator](https://github.com/oliver-gomes/react-native-bmi) | Feedback on Body mass index (BMI) to measure body fat based on height and weight. | Expo sdk 32.0.0 | Feb 15, 2019 | [Expo](https://expo.io/@ogomes/bmi-calculator) |
+| [Modern Twin Calculator](https://github.com/oliver-gomes/react-native-calculator) | Modern Calculator with Day/Night Switch help stand out in dark and light area | Expo sdk 32.0.0 | Feb 15, 2019 | [Expo](https://expo.io/@ogomes/twin-modern-calculator) |
+| [Github Gist Client - Arjun](https://github.com/Arjun-sna/react-native-githubgist-client) | Mobile client application for Github Gists | 0.57.8 | Jun 7, 2019 | [Google Play Store](https://play.google.com/store/apps/details?id=com.githubgist) |
+| [Helo Protocol](https://github.com/gagangoku/helo-protocol-rn) | Android / IOS app for Helo Protocol. Uses codepush to keep itself up to date. | 0.57.1 | Mar 23, 2019 | [](https://www.heloprotocol.in/helo-website-desktop/index.html)<br/> [Apple App Store](https://itunes.apple.com/gb/app/heloprotocol/id1455721517) |
+| [Meet Native](https://github.com/beauvaisbruno/meetnative) | An app to locate a language partner. | 0.58.6 | Apr 12, 2019 | - |
+| [Bon-Appetit!](https://github.com/steniowagner/bon-appetit-app) | A React-Native App that shows options of Restaurants, Gastronomic Events and Dishes in the City of Fortaleza (Brazil). | 0.57.8 | May 21, 2019 | - |
+| [Tip Advisor](https://github.com/charliemcg/TipAdvisor) | Tip calculator which adjusts for country and tipping situation. | 0.59.8 | Jun 15, 2019 | - |
+| [Tone Tracker](https://github.com/charliemcg/ToneTrackerRN) | This app allows users to track the life span of their guitar strings. | 0.59.5 | Jun 17, 2019 | [Apple App Store](https://itunes.apple.com/WebObjects/MZStore.woa/wa/viewSoftware?id=1464663060&mt=8)<br/> [Google Play Store](https://play.google.com/store/apps/details?id=com.violenthoboenterprises.tonetracker) |
+| [MindCast](https://github.com/steniowagner/mindCast) | A Podcast App that streams audio files from the server and has as main purpose "Share knowledge in the form of podcasts, providing a simple way to learn". | 0.58.4 | Oct 4, 2019 | - |
+| [Anime Jisho](https://github.com/AurangzaibRamzan/Anime-jisho) | A React native application for exploring the world of anime which includes multifaceted features including: search on board range of anime, details on particular anime i.e. characters, description, top trends etc. | 0.59.8 | Dec 23, 2019  | - |
+| [NSFWJS Mobile](https://github.com/infinitered/nsfwjs-mobile) | Client-side indecent content checking example app | 0.60.5 | Oct 24, 2019 | [Article](https://shift.infinite.red/nsfw-js-for-react-native-a37c9ba45fe9) |
+
+## Boilerplate React Native Apps
+
+| Title        | Description |
+| ------------ | -----------:|
+| [Context API Demo](https://github.com/ToJen/react_native_context_demo) | A simple app showing how Context API can be used in React Native by authenticating users. [Expo](https://expo.io/tools) and [React Navigation](https://reactnavigation.org/) were used for this. This is great for hackathons or quick projects! |
+| [React Native boilerplate](https://github.com/alexakasanjeev/react-native-boilerplate) | React native boiler plate code based on Atomic design, implements react navigation, redux, redux-saga and storybook. |
+| [React Native boileplate](https://github.com/tawachan/react-native-expo-boilerplate) | A boilerplate to develop a mobile app with React Native and Expo(v32) using TypeScript and Redux (Redux Saga). |
+
+## Core Contributors
 
 This list is curated by [Gant Laborde](https://twitter.com/gantlaborde), Chief Technology Strategist of [Infinite Red](https://infinite.red/react-native).
 
-
-### Boilerplate React Native Apps
-
-[Context API Demo](https://github.com/ToJen/react_native_context_demo) - A simple app showing how Context API can be used in React Native by authenticating users. [Expo](https://expo.io/tools) and [React Navigation](https://reactnavigation.org/) were used for this. This is great for hackathons or quick projects!
-
-[arcn](https://github.com/alexakasanjeev/arcn) - React native boiler plate code based on Atomic design, implements react navigation, redux, redux-saga and storybook.


### PR DESCRIPTION
## Summary
Hello, to increase the readability of the list, and to provide more context regarding the project, I have extracted the list into markdown table.

## Changes made:
1. Move the list to markdown table
2. Add two new column, `React Native Version` & `Last Commit` which tells the latest React-Native version & last commit on the GitHub repository at the day 18 Apr, 2020
3. Move all the repository that were updated in 2020 at the top of the list

## Following links were no longer valid, hence removed

- Facebook F8 App [Google Play Store](https://play.google.com/store/apps/details?id=com.facebook.f8)
- Hooligram [Google Play Store](https://play.google.com/store/apps/details?id=com.hooligram)
- Pocat [Google Play Store](https://play.google.com/store/apps/details?id=com.hecodesthings.pocat)
- Cryptobullography [Google Play Store](https://play.google.com/store/apps/details?id=com.webstew.bullet&hl=en)
- ndash [Google Play Store](https://play.google.com/store/apps/details?id=com.ndash)
- Hacker Buzz [Google Play Store](https://play.google.com/store/apps/details?id=com.hackerbuzz)
- F1 Stat [Google Play Store](https://play.google.com/store/apps/details?id=com.formula1info)
- Thousanday - Homepage for pets [Google Play](https://play.google.com/store/apps/details?id=com.thousanday)
- Helo Protocol [Google Play Store](https://play.google.com/store/apps/details?id=com.heloprotocol.customer.app.rn.notificationtester)

## Following repository were removed
- [Boost Note](https://github.com/BoostIO/boostnote-mobile), because it has been archieved by the maintainers and no longer maintained, and in place of that they have created new repo that uses electron & not react-native
- [Gas/Oil Mix Ratio Calculator](https://github.com/filippofilip95/gas-oil-mixture-mobile) repo no longer exists
- [Daily Prices](http://ansolutions.co/prices-today), no github link is provided, and website is down
- [Multiple Apps by Christopher Dro](https://github.com/christopherdro) in place of that I have mentioned one of his project (react-native-sudoku)
- [Hacker News React Native](https://github.com/iSimar/HackerNews-React-Native) mentioned on the repo that this project has been deprecated
- [FinanceReactNative](https://github.com/7kfpun/FinanceReactNative) mentioned on the repo that this project has been deprecated
- [Beer Calculator App](https://github.com/HugoDF/beercalculatorapp) repo has been archieved and has not been updated since 2015
- [FlexBox Froggy](https://github.com/browniefed/flexboxfroggy) very old project, not maintained since dec 22, 2015